### PR TITLE
Add support for nodemon via 'npm run dev'

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "start": "PORT=3001 node ./bin/www",
+    "dev": "PORT=3001 nodemon ./bin/www",
     "test": "NODE_ENV=test jest"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint": "^4.19.1",
     "eslint-plugin-react": "^7.7.0",
     "jest": "^22.4.3",
-    "react-test-renderer": "^16.3.1"
+    "react-test-renderer": "^16.3.1",
+    "nodemon": "^1.17.3"
   }
 }


### PR DESCRIPTION
Nodemon allows testing new code without the need to restart the server. Using nodemon, changes to relevant code automatically trigger the restart of the server, allowing faster development.